### PR TITLE
installation: fix invenio_base imports

### DIFF
--- a/invenio_annotations/api.py
+++ b/invenio_annotations/api.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -17,7 +17,7 @@
 # along with Invenio; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
-from invenio.base.globals import cfg
+from invenio_base.globals import cfg
 from invenio.modules.jsonalchemy.reader import Reader
 from invenio.modules.jsonalchemy.wrappers import SmartJsonLD
 

--- a/invenio_annotations/config.py
+++ b/invenio_annotations/config.py
@@ -21,7 +21,7 @@
 
 from __future__ import unicode_literals
 
-from invenio.base import config
+from invenio_base import config
 
 ANNOTATIONS_ENGINE = ('invenio.modules.jsonalchemy.jsonext.engines.'
                       'sqlalchemy:SQLAlchemyStorage')

--- a/invenio_annotations/forms.py
+++ b/invenio_annotations/forms.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -19,7 +19,7 @@
 
 from wtforms import BooleanField, HiddenField, TextAreaField, validators
 
-from invenio.base.i18n import _
+from invenio_base.i18n import _
 from invenio.modules.deposit.field_widgets import plupload_widget
 from invenio.modules.deposit.fields import FileUploadField
 from invenio.utils.forms import InvenioBaseForm

--- a/invenio_annotations/noteutils.py
+++ b/invenio_annotations/noteutils.py
@@ -29,7 +29,7 @@ import re
 
 from flask_login import current_user
 
-from invenio.base.i18n import _
+from invenio_base.i18n import _
 from invenio.ext.sqlalchemy import db
 from invenio.modules.accounts.models import User
 

--- a/invenio_annotations/receivers.py
+++ b/invenio_annotations/receivers.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -17,7 +17,7 @@
 # along with Invenio; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
-from invenio.base.globals import cfg
+from invenio_base.globals import cfg
 
 
 def extract_notes(mapper, connection, target):

--- a/invenio_annotations/testsuite/test_api.py
+++ b/invenio_annotations/testsuite/test_api.py
@@ -21,11 +21,11 @@ __revision__ = "$Id$"
 
 from datetime import datetime
 
-from invenio.base.wrappers import lazy_import
+from invenio_base.wrappers import lazy_import
 from invenio.testsuite import make_test_suite, run_test_suite, nottest, \
     InvenioTestCase
 
-CFG = lazy_import('invenio.base.globals.cfg')
+CFG = lazy_import('invenio_base.globals.cfg')
 USER = lazy_import('invenio.modules.accounts.models.User')
 API = lazy_import('invenio_annotations.api')
 NOTEUTILS = lazy_import('invenio_annotations.noteutils')

--- a/invenio_annotations/testsuite/test_noteutils.py
+++ b/invenio_annotations/testsuite/test_noteutils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -19,7 +19,7 @@
 
 __revision__ = "$Id$"
 
-from invenio.base.wrappers import lazy_import
+from invenio_base.wrappers import lazy_import
 from invenio.testsuite import make_test_suite, run_test_suite, InvenioTestCase
 
 EXTRACT_NOTES_FROM_COMMENT = \

--- a/invenio_annotations/views.py
+++ b/invenio_annotations/views.py
@@ -28,8 +28,8 @@ from flask import Blueprint, abort, current_app, flash, g, jsonify, redirect, \
 from flask_login import current_user, login_required
 from sqlalchemy.event import listen
 
-from invenio.base.globals import cfg
-from invenio.base.i18n import _
+from invenio_base.globals import cfg
+from invenio_base.i18n import _
 from invenio.utils.washers import wash_html_id
 from invenio_comments.models import CmtRECORDCOMMENT
 from invenio_comments.views import blueprint as comments_blueprint

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -29,3 +29,4 @@
 #     -e git+git://github.com/mitsuhiko/jinja2.git#egg=Jinja2
 
 -e git+git://github.com/inveniosoftware/invenio-access.git#egg=invenio-access
+-e git+git://github.com/inveniosoftware/invenio-base.git#egg=invenio-base

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ requirements = [
     'Flask>=0.10.1',
     'six>=1.7.2',
     'invenio-access>=0.1.0',
+    'invenio-base>=0.1.0',
     'invenio-comments>=0.1.0',
 ]
 


### PR DESCRIPTION
- FIX Adds missing `invenio_base` dependency and amends past
  upgrade recipes following its separation into standalone package.

Signed-off-by: Sami Hiltunen sami.mikael.hiltunen@cern.ch
