### PR TITLE
tests: fix pytest >=2.8.0 breaking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@
 notifications:
   email: false
 
+sudo: false
+
 services:
   - mysql
   - redis
@@ -43,10 +45,8 @@ python:
   - "2.7"
 
 before_install:
-  - "sudo apt-get update"
-  - "sudo apt-get install python-dev"
   - "travis_retry pip install --upgrade pip"
-  - "travis_retry pip install mock"
+  - "travis_retry pip install mock coveralls"
   - "python requirements.py --extras=$REXTRAS --level=min > .travis-lowest-requirements.txt"
   - "python requirements.py --extras=$REXTRAS --level=pypi > .travis-release-requirements.txt"
   - "python requirements.py --extras=$REXTRAS --level=dev > .travis-devel-requirements.txt"

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,9 @@ cache:
   - pip
 
 env:
-  - REQUIREMENTS=lowest REXTRAS=docs,test
-  - REQUIREMENTS=release REXTRAS=docs,test
-  - REQUIREMENTS=devel REXTRAS=docs,test
+  - REQUIREMENTS=lowest REXTRAS=docs,tests
+  - REQUIREMENTS=release REXTRAS=docs,tests
+  - REQUIREMENTS=devel REXTRAS=docs,tests
 
 python:
   - "2.7"

--- a/invenio_annotations/api.py
+++ b/invenio_annotations/api.py
@@ -18,8 +18,10 @@
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
 from invenio_base.globals import cfg
-from invenio.modules.jsonalchemy.reader import Reader
-from invenio.modules.jsonalchemy.wrappers import SmartJsonLD
+
+from jsonalchemy.reader import Reader, translate
+
+from jsonalchemy.wrappers import SmartJsonLD
 
 
 class QueryIterator():
@@ -52,8 +54,8 @@ class Annotation(SmartJsonLD):
 
     @classmethod
     def create(cls, data, model='annotation'):
-        dic = Reader.translate(data, cls, model=model, master_format='json',
-                               namespace="annotationsext")
+        dic = translate(data, cls, model=model, master_format='json',
+                        namespace="annotationsext")
         cls.storage_engine.save_one(dic.dumps())
         return dic
 
@@ -136,4 +138,4 @@ def get_count(uid, target):
                                    {"public": False, "groups": []}}).count()
     public = get_annotations({"where": target,
                               "perm": {"public": True, "groups": []}}).count()
-    return {"public": public, "private": private, "total": public+private}
+    return {"public": public, "private": private, "total": public + private}

--- a/invenio_annotations/bundles.py
+++ b/invenio_annotations/bundles.py
@@ -21,10 +21,13 @@
 
 from __future__ import unicode_literals
 
-from invenio_ext.assets import Bundle
-from invenio.modules.previewer.bundles import pdftk as _pdftk
 from invenio_comments.bundles import css as _commentscss
 from invenio_comments.bundles import js as _commentsjs
+
+from invenio_ext.assets import Bundle
+
+from invenio_previewer.bundles import pdftk as _pdftk
+
 
 _pdftk.contents += ("js/annotations/pdf_notes_helpers.js",)
 

--- a/invenio_annotations/bundles.py
+++ b/invenio_annotations/bundles.py
@@ -21,7 +21,7 @@
 
 from __future__ import unicode_literals
 
-from invenio.ext.assets import Bundle
+from invenio_ext.assets import Bundle
 from invenio.modules.previewer.bundles import pdftk as _pdftk
 from invenio_comments.bundles import css as _commentscss
 from invenio_comments.bundles import js as _commentsjs

--- a/invenio_annotations/config.py
+++ b/invenio_annotations/config.py
@@ -21,8 +21,6 @@
 
 from __future__ import unicode_literals
 
-from invenio_base import config
-
 ANNOTATIONS_ENGINE = ('invenio.modules.jsonalchemy.jsonext.engines.'
                       'sqlalchemy:SQLAlchemyStorage')
 

--- a/invenio_annotations/forms.py
+++ b/invenio_annotations/forms.py
@@ -17,12 +17,14 @@
 # along with Invenio; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
-from wtforms import BooleanField, HiddenField, TextAreaField, validators
-
 from invenio_base.i18n import _
-from invenio.modules.deposit.field_widgets import plupload_widget
-from invenio.modules.deposit.fields import FileUploadField
+
+from invenio_deposit.field_widgets import plupload_widget
+from invenio_deposit.fields import FileUploadField
+
 from invenio_utils.forms import InvenioBaseForm
+
+from wtforms import BooleanField, HiddenField, TextAreaField, validators
 
 
 class WebPageAnnotationForm(InvenioBaseForm):

--- a/invenio_annotations/models.py
+++ b/invenio_annotations/models.py
@@ -17,12 +17,15 @@
 # along with Invenio; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
+from invenio_accounts.models import User
+
 from invenio_ext.sqlalchemy import db
-from invenio.modules.accounts.models import User
+
 from invenio_records.models import Record as Bibrec
 
 
 class CmtNOTECOLLAPSED(db.Model):
+
     """Represents a CmtNOTECOLLAPSED record."""
 
     __tablename__ = 'cmtNOTECOLLAPSED'
@@ -56,4 +59,4 @@ class CmtNOTECOLLAPSED(db.Model):
                   unique=False)
 
 
-__all__ = ['CmtNOTECOLLAPSED']
+__all__ = ('CmtNOTECOLLAPSED')

--- a/invenio_annotations/models.py
+++ b/invenio_annotations/models.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -17,7 +17,7 @@
 # along with Invenio; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
-from invenio.ext.sqlalchemy import db
+from invenio_ext.sqlalchemy import db
 from invenio.modules.accounts.models import User
 from invenio_records.models import Record as Bibrec
 

--- a/invenio_annotations/noteutils.py
+++ b/invenio_annotations/noteutils.py
@@ -29,9 +29,11 @@ import re
 
 from flask_login import current_user
 
+from invenio_accounts.models import User
+
 from invenio_base.i18n import _
+
 from invenio_ext.sqlalchemy import db
-from invenio.modules.accounts.models import User
 
 # a note location can have one of the following structures (sans markers):
 # P.1, P.1,3,7 (multiple locations), F.1a, S.1.1 (sub-locations)
@@ -91,7 +93,7 @@ TEXT = r'(.+)'
 
 
 def extract_notes_from_comment(comment, bodyOnly=False):
-    """Extracts notes from a comment.
+    """Extract notes from a comment.
 
     Notes are one-line blocks of text preceded by :py:data:`MARKERS` and
     locations (page numbers, figure names etc.).
@@ -135,7 +137,7 @@ def extract_notes_from_comment(comment, bodyOnly=False):
 
 
 def get_original_comment(note):
-    """Fetches the original comment of the note; in case of hierarchic notes, it
+    """Fetche the original comment of the note; in case of hierarchic notes, it
     goes up to the parent.
 
     :param note: the note
@@ -196,7 +198,7 @@ def prepare_notes(notes):
 
 
 def note_collapse(id_bibrec, path):
-    """Collapses note category for user."""
+    """Collapse note category for user."""
     from .models import CmtNOTECOLLAPSED
     collapsed = CmtNOTECOLLAPSED(id_bibrec=id_bibrec,
                                  path=path,
@@ -204,12 +206,12 @@ def note_collapse(id_bibrec, path):
     try:
         db.session.add(collapsed)
         db.session.commit()
-    except:
+    except Exception:
         db.session.rollback()
 
 
 def note_expand(id_bibrec, path):
-    """Expands note category for user."""
+    """Expand note category for user."""
     from .models import CmtNOTECOLLAPSED
     CmtNOTECOLLAPSED.query.filter(db.and_(
         CmtNOTECOLLAPSED.id_bibrec == id_bibrec,
@@ -219,7 +221,7 @@ def note_expand(id_bibrec, path):
 
 
 def note_is_collapsed(id_bibrec, path):
-    """Checks if a note category is collapsed."""
+    """Check if a note category is collapsed."""
     from .models import CmtNOTECOLLAPSED
     return CmtNOTECOLLAPSED.query.filter(db.and_(
         CmtNOTECOLLAPSED.id_bibrec == id_bibrec,

--- a/invenio_annotations/noteutils.py
+++ b/invenio_annotations/noteutils.py
@@ -30,7 +30,7 @@ import re
 from flask_login import current_user
 
 from invenio_base.i18n import _
-from invenio.ext.sqlalchemy import db
+from invenio_ext.sqlalchemy import db
 from invenio.modules.accounts.models import User
 
 # a note location can have one of the following structures (sans markers):

--- a/invenio_annotations/restful.py
+++ b/invenio_annotations/restful.py
@@ -18,10 +18,12 @@
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
 from flask import request
-from flask_restful import Resource, abort
-from invenio_annotations.api import get_annotations, get_jsonld_multiple
 
-from invenio.modules.deposit.restful import require_header
+from flask_restful import Resource, abort
+
+from invenio_deposit.restful import require_header
+
+from .api import get_annotations, get_jsonld_multiple
 
 
 class AnnotationsListResource(Resource):
@@ -37,7 +39,7 @@ class AnnotationsListResource(Resource):
 
     @require_header('Content-Type', 'application/json')
     def post(self):
-        """POST method handler.
+        r"""POST method handler.
 
         Allows performing complex queries and exporting annotations in JSON-LD
         format. It accepts a JSON document as input, with the following
@@ -81,7 +83,7 @@ class AnnotationsListResource(Resource):
                                            new_context=rqj.get("new_context",
                                                                {}),
                                            format=rqj.get("ldexport", "full"))
-            except:
+            except Exception:
                 abort(400)
         return None
 

--- a/invenio_annotations/testsuite/test_api.py
+++ b/invenio_annotations/testsuite/test_api.py
@@ -22,11 +22,10 @@ __revision__ = "$Id$"
 from datetime import datetime
 
 from invenio_base.wrappers import lazy_import
-from invenio.testsuite import make_test_suite, run_test_suite, nottest, \
-    InvenioTestCase
+from invenio_testing import InvenioTestCase
 
 CFG = lazy_import('invenio_base.globals.cfg')
-USER = lazy_import('invenio.modules.accounts.models.User')
+USER = lazy_import('invenio_accounts.models.User')
 API = lazy_import('invenio_annotations.api')
 NOTEUTILS = lazy_import('invenio_annotations.noteutils')
 COMMENT = lazy_import('invenio_comments.models.CmtRECORDCOMMENT')
@@ -88,9 +87,3 @@ class TestJSONLD(AnnotationTestCase):
                        ["http://www.w3.org/ns/oa#hasSelector"]
                        ["http://www.w3.org/1999/02/22-rdf-syntax-ns#value"] ==
                      "P.1_T.2a.2_L.100")
-
-
-TEST_SUITE = make_test_suite(TestAnnotation, TestJSONLD)
-
-if __name__ == "__main__":
-    run_test_suite(TEST_SUITE)

--- a/invenio_annotations/testsuite/test_api.py
+++ b/invenio_annotations/testsuite/test_api.py
@@ -17,12 +17,11 @@
 # along with Invenio; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
-__revision__ = "$Id$"
-
 from datetime import datetime
 
 from invenio_base.wrappers import lazy_import
-from invenio_testing import InvenioTestCase
+
+from invenio_testing import InvenioTestCase, nottest
 
 CFG = lazy_import('invenio_base.globals.cfg')
 USER = lazy_import('invenio_accounts.models.User')

--- a/invenio_annotations/testsuite/test_noteutils.py
+++ b/invenio_annotations/testsuite/test_noteutils.py
@@ -20,7 +20,7 @@
 __revision__ = "$Id$"
 
 from invenio_base.wrappers import lazy_import
-from invenio.testsuite import make_test_suite, run_test_suite, InvenioTestCase
+from invenio_testing import InvenioTestCase
 
 EXTRACT_NOTES_FROM_COMMENT = \
     lazy_import(
@@ -32,6 +32,7 @@ PREPARE_NOTES = \
 
 
 class TestExtractNotes(InvenioTestCase):
+
     """Tests for comment note extraction"""
 
     def test_extract_notes_from_comment(self):
@@ -164,8 +165,3 @@ class TestExtractNotes(InvenioTestCase):
     def test_get_original_comment(self):
         # FIXME: implement
         pass
-
-TEST_SUITE = make_test_suite(TestExtractNotes)
-
-if __name__ == "__main__":
-    run_test_suite(TEST_SUITE)

--- a/invenio_annotations/views.py
+++ b/invenio_annotations/views.py
@@ -25,15 +25,20 @@ from urlparse import urlsplit
 
 from flask import Blueprint, abort, current_app, flash, g, jsonify, redirect, \
     render_template, request, url_for
+
 from flask_login import current_user, login_required
-from sqlalchemy.event import listen
 
 from invenio_base.globals import cfg
 from invenio_base.i18n import _
-from invenio_utils.washers import wash_html_id
+
 from invenio_comments.models import CmtRECORDCOMMENT
 from invenio_comments.views import blueprint as comments_blueprint
+
 from invenio_records.views import request_record
+
+from invenio_utils.washers import wash_html_id
+
+from sqlalchemy.event import listen
 
 from .api import add_annotation, get_annotations, get_count
 from .forms import WebPageAnnotationForm, WebPageAnnotationFormAttachments
@@ -70,7 +75,8 @@ def ping(message=""):
 @blueprint.route('/menu', methods=['GET'])
 def menu():
     """Menu page."""
-    # we need the after-login referrer to be the main page, not the modal dialog
+    # we need the after-login referrer to be the main page, not the modal
+    # dialog
     original_referrer = request.referrer
     annos = get_count(current_user.get_id(), urlsplit(original_referrer)[2])
     if not annos["total"]:
@@ -145,7 +151,8 @@ def attach():
 @login_required
 def detach():
     """Detach page."""
-    current_app.logger.info('Removal request: ' + request.values.get('file_id'))
+    current_app.logger.info(
+        'Removal request: ' + request.values.get('file_id'))
     return jsonify()
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -23,6 +23,6 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 [pytest]
-addopts = --clearcache --pep8 --ignore=docs --cov=invenio_annotations --cov-report=term-missing
+addopts = --pep8 --ignore=docs --cov=invenio_annotations --cov-report=term-missing
 pep8ignore =
     tests/* ALL

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -21,13 +21,9 @@
 # In applying this license, CERN does not
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
-#
-# TODO: Add development versions of some important dependencies here to get a
-#       warning when there are breaking upstream changes, e.g.:
-#
-#     -e git+git://github.com/mitsuhiko/werkzeug.git#egg=Werkzeug
-#     -e git+git://github.com/mitsuhiko/jinja2.git#egg=Jinja2
 
 -e git+git://github.com/inveniosoftware/invenio-access.git#egg=invenio-access
+-e git+git://github.com/inveniosoftware/invenio-accounts.git#egg=invenio-accounts
 -e git+git://github.com/inveniosoftware/invenio-base.git#egg=invenio-base
+-e git+git://github.com/inveniosoftware/invenio-testing.git#egg=invenio-testing
 -e git+git://github.com/inveniosoftware/invenio-utils.git#egg=invenio-utils

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -27,3 +27,4 @@
 -e git+git://github.com/inveniosoftware/invenio-base.git#egg=invenio-base
 -e git+git://github.com/inveniosoftware/invenio-testing.git#egg=invenio-testing
 -e git+git://github.com/inveniosoftware/invenio-utils.git#egg=invenio-utils
+-e git+git://github.com/inveniosoftware/jsonalchemy.git#egg=jsonalchemy

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ requirements = [
     'six>=1.7.2',
     'invenio-access>=0.1.0',
     'invenio-accounts>=0.1.2',
-    'invenio-base>=0.1.0',
+    'invenio-base>=0.3.0',
     'invenio-comments>=0.1.0',
     'invenio-utils>=0.1.1',
 ]

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ requirements = [
     'Flask>=0.10.1',
     'six>=1.7.2',
     'invenio-access>=0.1.0',
+    'invenio-accounts>=0.1.2',
     'invenio-base>=0.1.0',
     'invenio-comments>=0.1.0',
     'invenio-utils>=0.1.1',
@@ -47,6 +48,7 @@ test_requirements = [
     'pytest-cov>=2.1.0',
     'pytest-pep8>=1.0.6',
     'coverage>=4.0.0',
+    'invenio-testing>=0.1.1',
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -35,12 +35,22 @@ history = open('CHANGES.rst').read()
 
 requirements = [
     'Flask>=0.10.1',
-    'six>=1.7.2',
+    'Flask-Login>=0.2.7',
+    'Flask-RESTful>=0.2.12',
+    'Flask-WTF>=0.10.2',
     'invenio-access>=0.1.0',
-    'invenio-accounts>=0.1.2',
+    'invenio-accounts>=0.2.0',
     'invenio-base>=0.3.0',
     'invenio-comments>=0.1.0',
+    'invenio-deposit>=0.2.0',
+    'invenio-ext>=0.3.1',
+    'invenio-previewer>=0.1.0',
+    'invenio-records>=0.3.3',
     'invenio-utils>=0.2.0',
+    'jsonalchemy>=0.0.0',
+    'six>=1.7.2',
+    'SQLAlchemy>=1.0',
+    'WTForms>=2.0.1',
 ]
 
 test_requirements = [

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ requirements = [
     'invenio-accounts>=0.1.2',
     'invenio-base>=0.3.0',
     'invenio-comments>=0.1.0',
-    'invenio-utils>=0.1.1',
+    'invenio-utils>=0.2.0',
 ]
 
 test_requirements = [

--- a/setup.py
+++ b/setup.py
@@ -43,10 +43,10 @@ requirements = [
 ]
 
 test_requirements = [
-    'pytest>=2.7.0',
-    'pytest-cov>=1.8.0',
+    'pytest>=2.8.0',
+    'pytest-cov>=2.1.0',
     'pytest-pep8>=1.0.6',
-    'coverage>=3.7.1',
+    'coverage>=4.0.0',
 ]
 
 
@@ -78,9 +78,6 @@ class PyTest(TestCommand):
         """Run tests."""
         # import here, cause outside the eggs aren't loaded
         import pytest
-        import _pytest.config
-        pm = _pytest.config.get_plugin_manager()
-        pm.consider_setuptools_entrypoints()
         errno = pytest.main(self.pytest_args)
         sys.exit(errno)
 


### PR DESCRIPTION
- FIX pytest 2.8.0 removed functionality used for tests. This removes
  calls to the removed functions.

Signed-off-by: Sami Hiltunen sami.mikael.hiltunen@cern.ch
