### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -26,4 +26,4 @@ Authors
 
 Invenio module that adds document annotation support.
 
-- CERN <info@invenio-software.org>
+- CERN <info@inveniosoftware.org>

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ setup(
     keywords='invenio TODO',
     license='GPLv2',
     author='CERN',
-    author_email='info@invenio-software.org',
+    author_email='info@inveniosoftware.org',
     url='https://github.com/inveniosoftware/invenio-annotations',
     packages=[
         'invenio_annotations',


### PR DESCRIPTION
- Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko tibor.simko@cern.ch
